### PR TITLE
Added empty dict variable `tags` for conf.py

### DIFF
--- a/sphinx_intl/commands.py
+++ b/sphinx_intl/commands.py
@@ -28,6 +28,7 @@ ENVVAR_PREFIX = 'SPHINXINTL'
 def read_config(path):
     namespace = {
         "__file__": os.path.abspath(path),
+        "tags": dict(),
     }
     olddir = os.getcwd()
     try:


### PR DESCRIPTION
According to the [documentation of conf.py](http://www.sphinx-doc.org/en/stable/config.html), there is a special object named tags available in the config file. 

Therefore, in order to maintain compatibility with sphinx, the conf.py for the sphinx-intl should also be able to access the global variable `tags`.

So, an empty dictionary variable to added.