### PR TITLE
Fixes #17: Adding --tag -t option, to pass tags from arguments to conf.py

### DIFF
--- a/sphinx_intl/commands.py
+++ b/sphinx_intl/commands.py
@@ -81,6 +81,7 @@ class TagsType(click.ParamType):
         tags = value.split(',')
         return tuple(tags)
 
+
 TAGS = TagsType()
 
 


### PR DESCRIPTION
I noticed that this is the only relevant argument to pass to sphinx-build. I based 'tag' argument on 'language' argument in commands.py

I also run all tests and they are passing well.

An example of usage is:
```
sphinx-intl -t mytag1,mytag2 update -l es
```