### PR TITLE
make sphinx-intl reproducible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [egg_info]
 tag_build = dev
-tag_date = true
 
 [build]
 build-base = _build


### PR DESCRIPTION
We Debian now try to make package build reproducible.
See Reproducible Builds https://reproducible-builds.org and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=881258

Could you consider to accept this change to make it happen, please?