### PR TITLE
Add another reserved Transifex slug `settings`

### DIFF
--- a/sphinx_intl/transifex.py
+++ b/sphinx_intl/transifex.py
@@ -15,9 +15,12 @@ from .catalog import load_po
 
 # To avoid using invalid resource name, append underscore to such names.
 # As a limitation, append `_` doesn't care about collision to other resources.
-# e.g. 'glossary' and 'glossary_' are pushed as a 'glossary_'.
+# e.g. 'glossary' and 'glossary_' are pushed as a 'glossary_'. The following
+# resource names are reserved slugs, Transifex will reply with an error on these
+# resource names.
 IGNORED_RESOURCE_NAMES = (
-    'glossary',  # transifex reject this name
+    'glossary',
+    'settings',
 )
 
 TRANSIFEXRC_TEMPLATE = """\

--- a/tests/test_transifex.py
+++ b/tests/test_transifex.py
@@ -127,6 +127,7 @@ def test_update_txconfig_resources_with_potfile_including_symbols(home_in_temp, 
     ('spam-ham/egg.pot', 'spam-ham--egg_pot'),
     ('glossary', 'glossary_'),
     ('glossary_', 'glossary_'),
+    ('settings', 'settings_'),
 ])
 def test_normalize_resource_name(input, expected):
     _callSUT = transifex.normalize_resource_name


### PR DESCRIPTION
Apparently this is also reserved, as I received an error response about
the slug being reserved.