### PR TITLE
Fix "build" subcommand/method documentation

### DIFF
--- a/sphinx_intl/basic.py
+++ b/sphinx_intl/basic.py
@@ -75,7 +75,7 @@ def update(locale_dir, pot_dir, languages, line_width=76):
 
 def build(locale_dir, output_dir, languages):
     """
-    Update specified language's po files from pot.
+    Build specified language's po files into mo.
 
     :param unicode locale_dir: path for locale directory
     :param unicode output_dir: path for mo output directory

--- a/sphinx_intl/commands.py
+++ b/sphinx_intl/commands.py
@@ -269,7 +269,7 @@ def update(locale_dir, pot_dir, language, line_width):
 @option_language
 def build(locale_dir, output_dir, language):
     """
-    Update specified language's po files from pot.
+    Build specified language's po files into mo.
     """
     if not language:
         language = get_lang_dirs(locale_dir)


### PR DESCRIPTION
I fixed the documentation for the subcommand `build`.

The documentation for `build` subcommand was the same as `update` and it seemed inaccurate.
I also fixed the `build` method documentation in `basic.py`.