### PR TITLE
Support no obsolete option

### DIFF
--- a/sphinx_intl/basic.py
+++ b/sphinx_intl/basic.py
@@ -22,7 +22,7 @@ def get_lang_dirs(path):
 # ==================================
 # commands
 
-def update(locale_dir, pot_dir, languages, line_width=76):
+def update(locale_dir, pot_dir, languages, line_width=76, ignore_obsolete=False):
     """
     Update specified language's po files from pot.
 
@@ -30,6 +30,7 @@ def update(locale_dir, pot_dir, languages, line_width=76):
     :param unicode pot_dir: path for pot directory
     :param tuple languages: languages to update po files
     :param number line_width: maximum line width of po files
+    :param bool ignore_obsolete: ignore obsolete entries in po files
     :return: {'create': 0, 'update': 0, 'notchanged': 0}
     :rtype: dict
     """
@@ -61,7 +62,8 @@ def update(locale_dir, pot_dir, languages, line_width=76):
                         status['update'] += 1
                         click.echo('Update: {0} +{1}, -{2}'.format(
                             po_file, len(added), len(deleted)))
-                        c.dump_po(po_file, cat, width=line_width)
+                        c.dump_po(po_file, cat, width=line_width,
+                                  ignore_obsolete=ignore_obsolete)
                     else:
                         status['notchanged'] += 1
                         click.echo('Not Changed: {0}'.format(po_file))
@@ -69,7 +71,8 @@ def update(locale_dir, pot_dir, languages, line_width=76):
                     status['create'] += 1
                     click.echo('Create: {0}'.format(po_file))
                     cat_pot.locale = lang
-                    c.dump_po(po_file, cat_pot, width=line_width)
+                    c.dump_po(po_file, cat_pot, width=line_width,
+                              ignore_obsolete=ignore_obsolete)
 
     return status
 

--- a/sphinx_intl/basic.py
+++ b/sphinx_intl/basic.py
@@ -61,7 +61,7 @@ def update(locale_dir, pot_dir, languages, line_width=76):
                         status['update'] += 1
                         click.echo('Update: {0} +{1}, -{2}'.format(
                             po_file, len(added), len(deleted)))
-                        c.dump_po(po_file, cat, line_width)
+                        c.dump_po(po_file, cat, width=line_width)
                     else:
                         status['notchanged'] += 1
                         click.echo('Not Changed: {0}'.format(po_file))
@@ -69,7 +69,7 @@ def update(locale_dir, pot_dir, languages, line_width=76):
                     status['create'] += 1
                     click.echo('Create: {0}'.format(po_file))
                     cat_pot.locale = lang
-                    c.dump_po(po_file, cat_pot, line_width)
+                    c.dump_po(po_file, cat_pot, width=line_width)
 
     return status
 

--- a/sphinx_intl/basic.py
+++ b/sphinx_intl/basic.py
@@ -29,7 +29,7 @@ def update(locale_dir, pot_dir, languages, line_width=76):
     :param unicode locale_dir: path for locale directory
     :param unicode pot_dir: path for pot directory
     :param tuple languages: languages to update po files
-    :param number line_width: maximum line wdith of po files
+    :param number line_width: maximum line width of po files
     :return: {'create': 0, 'update': 0, 'notchanged': 0}
     :rtype: dict
     """

--- a/sphinx_intl/catalog.py
+++ b/sphinx_intl/catalog.py
@@ -6,10 +6,11 @@ import io
 from babel.messages import pofile, mofile
 
 
-def load_po(filename):
+def load_po(filename, **kwargs):
     """read po/pot file and return catalog object
 
     :param unicode filename: path to po/pot file
+    :param kwargs: keyword arguments to forward to babel's read_po call
     :return: catalog object
     """
     # pre-read to get charset
@@ -20,27 +21,36 @@ def load_po(filename):
     # To decode lines by babel, read po file as binary mode and specify charset for
     # read_po function.
     with io.open(filename, 'rb') as f:  # FIXME: encoding VS charset
-        return pofile.read_po(f, charset=charset)
+        return pofile.read_po(f, charset=charset, **kwargs)
 
 
-def dump_po(filename, catalog, line_width=76):
+def dump_po(filename, catalog, **kwargs):
     """write po/pot file from catalog object
 
     :param unicode filename: path to po file
     :param catalog: catalog object
-    :param line_width: maximum line wdith of po files
+    :param kwargs: keyword arguments to forward to babel's write_po call; also
+                    accepts a deprecated `line_width` option to forward to
+                    write_po's `width` option
     :return: None
     """
     dirname = os.path.dirname(filename)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 
+    # (compatibility) line_width was the original argument used to forward
+    # line width hints into write_po's `width` argument; if provided,
+    # set/override the width value
+    if 'line_width' in kwargs:
+        kwargs['width'] = kwargs['line_width']
+        del kwargs['line_width']
+
     # Because babel automatically encode strings, file should be open as binary mode.
     with io.open(filename, 'wb') as f:
-        pofile.write_po(f, catalog, line_width)
+        pofile.write_po(f, catalog, **kwargs)
 
 
-def write_mo(filename, catalog):
+def write_mo(filename, catalog, **kwargs):
     """write mo file from catalog object
 
     :param unicode filename: path to mo file
@@ -51,7 +61,7 @@ def write_mo(filename, catalog):
     if not os.path.exists(dirname):
         os.makedirs(dirname)
     with io.open(filename, 'wb') as f:
-        mofile.write_mo(f, catalog)
+        mofile.write_mo(f, catalog, **kwargs)
 
 
 def translated_entries(catalog):

--- a/sphinx_intl/commands.py
+++ b/sphinx_intl/commands.py
@@ -130,6 +130,12 @@ option_line_width = click.option(
     help='The maximum line width for the po files, 0 or a negative number '
          'disable line wrapping')
 
+option_no_obsolete = click.option(
+    '--no-obsolete',
+    envvar=ENVVAR_PREFIX + '_NO_OBSOLETE',
+    is_flag=True, default=False,
+    help='Remove obsolete #~ messages.')
+
 option_transifex_token = click.option(
     '--transifex-token',
     envvar=ENVVAR_PREFIX + '_TRANSIFEX_TOKEN',
@@ -234,7 +240,8 @@ def main(ctx, config, tag):
 @option_pot_dir
 @option_language
 @option_line_width
-def update(locale_dir, pot_dir, language, line_width):
+@option_no_obsolete
+def update(locale_dir, pot_dir, language, line_width, no_obsolete):
     """
     Update specified language's po files from pot.
 
@@ -260,7 +267,7 @@ def update(locale_dir, pot_dir, language, line_width):
                % locals())
         raise click.BadParameter(msg, param_hint='language')
 
-    basic.update(locale_dir, pot_dir, languages, line_width)
+    basic.update(locale_dir, pot_dir, languages, line_width, ignore_obsolete=no_obsolete)
 
 
 @main.command()


### PR DESCRIPTION
The following series of commits aims to bring support for a `--no-obsolete` option for a sphinx-intl update request. This option allows a caller to automatically drop/ignore obsolete messages processed from any updated documents (mimicking a `--no-obsolete` option found in [msgattrib][msgattrib]).

This commit stacks first adds a unit test to verify the existing line-width option. This is to not only help verify this option for long-term use, but ensure/present that the catalog changes presented in this pull request do not break its functionality. The "no obsolete" feature then follows the same style of configuring/utilizing the respective babel catalog option, as done with the line-width feature.

This pull request may make #61 obsolete with the introduction of e5e1870effc171557bcb59a3bca31d0cc388b45e; however, it is unknown if the `sort_by_message_location` proxy argument for babel's `sort_by_file` is required for its use case.

[msgattrib]: https://www.gnu.org/software/gettext/manual/html_node/msgattrib-Invocation.html
