### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
       max-parallel: 1
@@ -54,6 +55,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         env: [flake8, mypy]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
       max-parallel: 1
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
         run: echo $GITHUB_CONTEXT
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: pycache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: pycache
         with:
           path: ~/.cache/pip
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Setup python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         if: "!endsWith(matrix.python-version, '-dev')"
         with:
           python-version: ${{ matrix.python-version }}
@@ -61,12 +61,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ extras_require = {
     'test': [
         'pytest',
         'mock',
+        'six',
     ],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38,39,310-dev},
+    py{35,36,37,38,39,310},
     flake8,
     mypy
 
@@ -11,7 +11,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310-dev
+    3.10: py310
 
 [testenv]
 deps=-e.[transifex,test]


### PR DESCRIPTION
- Update actions used. In particular, setup-python<4 uses node.js 12, which is deprecated.
- Python 3.10 is released, so moving it from -dev to release.
- Adds 'fail-fast: false' allows all Python versions set and flake8 and mypy run, instead of stopping the rest when one fails
- Add 'six' as dependency for test environment to satisfy tests/path.py.

P.S.: the workflow is failing due to changes from 6b3913f, as can be seen in tox logs.