### PR TITLE
Add Trasifex CLI tool to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions
 
+      - name: Install Transifex CLI
+        run: |
+          curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+          mv tx /usr/local/bin/tx
+
       - name: Run tox
         run: |
           python -V


### PR DESCRIPTION
Fix tests that are failing on updating trasifex resources. See discussion in #68