### PR TITLE
Update documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,8 +23,7 @@ Bug Fixes
 ---------
 - #53: Set locale of created po files
 - #55: FileNotFoundError on update-txconfig-resources in the subdirectory
-- #72: Enable build of 3.11 and 3.12
-- #73: Fix issues reported by flake8
+- #72: Declare support for Python 3.11 and Python 3.12
 
 2.0.1 (2020/04/11)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,19 +7,24 @@ CHANGES
 
 Environments
 ------------
+- #71: Drop Python 3.5 support
 
 Incompatibility
 ---------------
 
 Features
 --------
+- #62: Migrate from transifex-client to transifex cli
 
 Documentation
 -------------
 
 Bug Fixes
 ---------
+- #53: Set locale of created po files
 - #55: FileNotFoundError on update-txconfig-resources in the subdirectory
+- #72: Enable build of 3.11 and 3.12
+- #73: Fix issues reported by flake8
 
 2.0.1 (2020/04/11)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ CHANGES
 Environments
 ------------
 - #71: Drop Python 3.5 support
+- #72: Declare support for Python 3.11 and Python 3.12
 
 Incompatibility
 ---------------
@@ -23,7 +24,6 @@ Bug Fixes
 ---------
 - #53: Set locale of created po files
 - #55: FileNotFoundError on update-txconfig-resources in the subdirectory
-- #72: Declare support for Python 3.11 and Python 3.12
 
 2.0.1 (2020/04/11)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,9 @@ Optional: support the Transifex service for translation with Sphinx_ .
    :alt: License
    :target: https://github.com/sphinx-doc/sphinx-intl/blob/master/LICENSE
 
-.. image:: https://img.shields.io/travis/sphinx-doc/sphinx-intl/master.svg
-   :alt: Travis (.org) branch
-   :target: https://travis-ci.org/sphinx-doc/sphinx-intl
+.. image:: https://github.com/sphinx-doc/sphinx-intl/actions/workflows/test.yml/badge.svg?branch=master
+   :alt: GitHub Actions CI status
+   :target: https://github.com/sphinx-doc/sphinx-intl/actions/workflows/test.yml
 
 .. image:: https://img.shields.io/github/stars/sphinx-doc/sphinx-intl.svg?style=social&label=Stars
    :alt: GitHub stars

--- a/checklist.rst
+++ b/checklist.rst
@@ -2,7 +2,7 @@
 
 Procedure:
 
-1. check travis-ci testing result: https://travis-ci.org/sphinx-doc/sphinx-intl
+1. check GitHub Actions test results: https://github.com/sphinx-doc/sphinx-intl/actions
 2. update release version/date in ``CHANGES.rst``
 3. ``python setup.py release sdist bdist_egg``
 4. ``twine upload dist/<target-package-file>``

--- a/doc/basic.rst
+++ b/doc/basic.rst
@@ -13,7 +13,7 @@ Basic Features
 
 Optional features
 ==================
-These features depends to `transifex-client`_ library.
+These features depends on `transifex-client`_ tool.
 Please refer Installation_ section to install it.
 
 * create ``.transifexrc`` file from environment variable, without interactive
@@ -27,17 +27,16 @@ You need to use `tx` command for below features:
 * ``tx push -s`` : push pot (translation catalogs) to transifex.
 * ``tx pull -l ja`` : pull po (translated catalogs) from transifex.
 
-.. _transifex-client: https://pypi.python.org/pypi/transifex-client
+.. _transifex-client: https://github.com/transifex/cli
 
 
 Installation
 =============
 
-Recommend strongly: use virtualenv/venv for this procedure::
+It is strongly recommended to use virtualenv/venv for this procedure::
 
    $ pip install sphinx-intl
 
-If you want to use `Optional Features`_, you need install additional library::
-
-   $ pip install sphinx-intl[transifex]
+If you want to use `Optional Features`_, you need install Transifex CLI tool.
+Please refer to `Installation instructions <https://github.com/transifex/cli#installation>`.
 

--- a/doc/basic.rst
+++ b/doc/basic.rst
@@ -13,7 +13,7 @@ Basic Features
 
 Optional features
 ==================
-These features depends on `transifex-client`_ tool.
+These features depends on the `transifex-client`_ tool.
 Please refer Installation_ section to install it.
 
 * create ``.transifexrc`` file from environment variable, without interactive

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -16,10 +16,14 @@ Setup development environment
 =============================
 
 * Requires supported Python version
-* do setup under sphinx-intl.git repository root as::
+* Do setup under sphinx-intl.git repository root as::
 
     $ pip install -U pip setuptools wheel setuptools_scm
     $ pip install -r requirements-testing.txt
+
+* Install Transifex CLI tool (refer to `Installation instructions <https://github.com/transifex/cli#installation>`_)::
+
+    $ curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 
 Testing
 =======
@@ -28,8 +32,7 @@ Tests with supported python version that are in:
 
 * ``setup.py``
 * ``tox.ini``
-* ``.travis.yml``
-
+* ``.github/workflow/test.yml``
 
 Run test
 --------
@@ -43,9 +46,9 @@ tox have several sections for testing.
 CI (Continuous Integration)
 ----------------------------
 
-All tests will be run on Travis CI service.
+All tests will be run on GitHub Actions.
 
-* https://travis-ci.org/sphinx-doc/sphinx-intl
+* https://github.com/sphinx-doc/sphinx-intl/tree/master/.github/workflows/
 
 Releasing
 =========
@@ -55,7 +58,7 @@ New package version
 
 The sphinx-intl package will be uploaded to PyPI: https://pypi.org/project/sphinx-intl/.
 
-Here is a release procefure for releasing.
+Here is a release procedure for releasing.
 
 .. include:: ../checklist.rst
 

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -58,7 +58,7 @@ New package version
 
 The sphinx-intl package will be uploaded to PyPI: https://pypi.org/project/sphinx-intl/.
 
-Here is a release procedure for releasing.
+Here is a release procedure:
 
 .. include:: ../checklist.rst
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,9 +23,9 @@ Optional: support the Transifex service for translation with Sphinx_ .
    :alt: License
    :target: https://github.com/sphinx-doc/sphinx-intl/blob/master/LICENSE
 
-.. image:: https://img.shields.io/travis/sphinx-doc/sphinx-intl/master.svg
-   :alt: Travis (.org) branch
-   :target: https://travis-ci.org/sphinx-doc/sphinx-intl
+.. image:: https://github.com/sphinx-doc/sphinx-intl/actions/workflows/test.yml/badge.svg?branch=master
+   :alt: GitHub Actions CI status
+   :target: https://github.com/sphinx-doc/sphinx-intl/actions/workflows/test.yml
 
 .. image:: https://img.shields.io/github/stars/sphinx-doc/sphinx-intl.svg?style=social&label=Stars
    :alt: GitHub stars


### PR DESCRIPTION
- Add latest changes into CHANGES.rst
- Update CI status badge in README and doc/index.rst, as CI changed from Travis to GitHub Actions
- Also update development instructions with new CI solution
- Replace info regarding old Python transifex-client library with the new implementation of Transifex CLI tool

P.s.: I did not add latest CI-specific pull requests to CHANGES.rst as they were not added in previous changes before, so I'm assuming it is intentional not add them.