### PR TITLE
add target to python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ Optional: support the Transifex service for translation with Sphinx_ .
 
 .. image:: https://img.shields.io/pypi/pyversions/sphinx-intl.svg
    :alt: PyPI - Python Version
+   :target: http://pypi.org/p/sphinx-intl
 
 .. image:: https://img.shields.io/github/license/sphinx-doc/sphinx-intl.svg
    :alt: License


### PR DESCRIPTION
If you don't set the target to all `image` directives GitHub adds an artificial linebreak

before: 

<img width="874" alt="Capture d’écran 2023-02-03 à 14 43 51" src="https://user-images.githubusercontent.com/12596392/216618614-64efe115-1303-4f4d-b689-470104f77dd9.png">

after: 
<img width="1050" alt="Capture d’écran 2023-02-03 à 14 44 02" src="https://user-images.githubusercontent.com/12596392/216618673-9f569d47-07e9-4638-a361-e12066783458.png">

