### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12-dev']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12-dev']
       max-parallel: 1
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -61,7 +60,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     extras_require=extras_require,
     entry_points="""\
     [console_scripts]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    py{36,37,38,39,310,311,312-dev},
+    py{37,38,39,310,311,312-dev},
     flake8,
     mypy
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
because...

- 2021-12-23, 3.6 has reached the end-of-life https://peps.python.org/pep-0494/#lifespan
- ubuntu-latest (22.04) doesn't support python-3.6 as: https://github.com/sphinx-doc/sphinx-intl/actions/runs/4090490381/jobs/7053940455

<img width="648" alt="image" src="https://user-images.githubusercontent.com/151623/216755284-26b4114f-b51b-4398-8eb4-1fb7e70b30b1.png">
