### PR TITLE
Set resource_name in .tx/config files to preserve resource naming behavior prior to 2.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Incompatibility
 
 Features
 --------
+- #90: ``update-txconfig-resources`` command sets ``resource_name`` in the ``.tx/config`` file to match the resource's slug.
 
 Documentation
 -------------

--- a/sphinx_intl/transifex.py
+++ b/sphinx_intl/transifex.py
@@ -153,7 +153,8 @@ def update_txconfig_resources(transifex_organization_name, transifex_project_nam
         'add',
         '--organization', '%(transifex_organization_name)s',
         '--project', '%(transifex_project_name)s',
-        '--resource', '%(resource_name)s',
+        '--resource', '%(resource_slug)s',
+        '--resource-name', '%(resource_name)s',
         '--file-filter', '%(locale_dir)s/<lang>/LC_MESSAGES/%(resource_path)s.po',
         '--type', 'PO',
         '%(pot_dir)s/%(resource_path)s.pot',
@@ -174,7 +175,7 @@ def update_txconfig_resources(transifex_organization_name, transifex_project_nam
     ) as progress_bar:
         for pot_path in progress_bar:
             resource_path = str(pot_path.relative_to(pot_dir).with_suffix(''))
-            resource_name = normalize_resource_name(resource_path)
+            resource_slug = resource_name = normalize_resource_name(resource_path)
             pot = load_po(str(pot_path))
             if len(pot):
                 lv = locals()

--- a/tests/test_cmd_transifex.py
+++ b/tests/test_cmd_transifex.py
@@ -73,6 +73,7 @@ def test_update_txconfig_resources_with_config(home_in_temp, temp):
 
     data = (tx_dir / 'config').text()
     assert re.search(r'\[o:eggs-org:p:ham-project:r:README\]', data)
+    assert re.search(r'\nresource_name = README\n', data)
 
 
 def test_update_txconfig_resources_with_pot_dir_argument(home_in_temp, temp):
@@ -95,6 +96,7 @@ def test_update_txconfig_resources_with_pot_dir_argument(home_in_temp, temp):
 
     data = (tx_dir / 'config').text().replace('\\', '/')
     assert re.search(r'\[o:eggs-org:p:ham-project:r:README\]', data)
+    assert re.search(r'\nresource_name = README\n', data)
     assert re.search(r'source_file\W*=\W*_build/locale/README.pot', data)
 
 
@@ -118,6 +120,7 @@ def test_update_txconfig_resources_with_project_name_including_dots(home_in_temp
 
     data = (tx_dir / 'config').text()
     assert re.search(r'\[o:eggs-org:p:ham-projectcom:r:README\]', data)
+    assert re.search(r'\nresource_name = README\n', data)
 
 
 def test_update_txconfig_resources_with_project_name_including_spaces(home_in_temp, temp):
@@ -140,6 +143,7 @@ def test_update_txconfig_resources_with_project_name_including_spaces(home_in_te
 
     data = (tx_dir / 'config').text()
     assert re.search(r'\[o:eggs-org:p:ham-project-com:r:README\]', data)
+    assert re.search(r'\nresource_name = README\n', data)
 
 
 def test_update_txconfig_resources_with_potfile_including_symbols(home_in_temp, temp):
@@ -170,3 +174,33 @@ def test_update_txconfig_resources_with_potfile_including_symbols(home_in_temp, 
     data = (tx_dir / 'config').text()
     assert re.search(r'\[o:eggs-org:p:ham-project-com:r:example_document\]', data)
     assert re.search(r'\[o:eggs-org:p:ham-project-com:r:test_document\]', data)
+    assert re.search(r'\nresource_name = example_document\n', data)
+    assert re.search(r'\nresource_name = test_document\n', data)
+
+
+def test_update_txconfig_resources_with_potfile_including_path_separators(home_in_temp, temp):
+    tx_dir = temp / '.tx'
+    tx_dir.makedirs()
+    (tx_dir / 'config').write_text(dedent("""\
+    [main]
+    host = https://www.transifex.com
+    """))
+
+    (temp / '_build' / 'locale').copytree(temp / 'locale' / 'pot')
+
+    # copy README.pot to 'example document.pot'
+    readme = (temp / '_build' / 'locale' / 'README.pot').text()
+    (temp / '_build' / 'locale' / 'example').makedirs()
+    (temp / '_build' / 'locale' / 'example' / 'document.pot').write_text(readme)
+
+    r1 = runner.invoke(commands.main,
+                       ['update-txconfig-resources',
+                        '-d', 'locale',
+                        '--transifex-organization-name', 'eggs-org',
+                        '--transifex-project-name', 'ham project com',
+                        ])
+    assert r1.exit_code == 0
+
+    data = (tx_dir / 'config').text()
+    assert re.search(r'\[o:eggs-org:p:ham-project-com:r:example--document\]', data)
+    assert re.search(r'\nresource_name = example--document\n', data)


### PR DESCRIPTION
closes #88