### PR TITLE
Drop six from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ classifiers = [
 test = [
     "pytest",
     "mock",
-    "six",
 ]
 
 [project.urls]


### PR DESCRIPTION
Six was dropped in #87, but not when creating pyproject.toml in #86. So removing it now.