### PR TITLE
add readthedocs conf

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+sphinx:
+  configuration: doc/conf.py
+
+python:
+  install:
+    - requirements: doc/requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
by https://blog.readthedocs.com/migrate-configuration-v2/

refs: https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install