### PR TITLE
Update version in workflow actions and enable 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12-dev']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
       max-parallel: 1
 
     steps:
@@ -36,15 +36,9 @@ jobs:
 
       - name: Setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
-        if: "!endsWith(matrix.python-version, '-dev')"
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Setup python ${{ matrix.python-version }} (via deadsnakes)
-        uses: deadsnakes/action@v2.1.1
-        if: "endsWith(matrix.python-version, '-dev')"
-        with:
-          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install tox and test related
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo $GITHUB_CONTEXT
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Setup python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         if: "!endsWith(matrix.python-version, '-dev')"
         with:
           python-version: ${{ matrix.python-version }}
@@ -66,12 +66,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Sphinx",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311,312-dev},
+    py{37,38,39,310,311,312,313},
     flake8,
     mypy
 
@@ -11,7 +11,8 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    3.12: py312-dev
+    3.12: py312
+    3.13: py313
 
 [testenv]
 deps=-e.[transifex,test]


### PR DESCRIPTION
This PR changes the following:
- Updates the CI workflow with newer action versions
- Drops deadsnakes action in favor for action/setup-python's `allow-prereleases` (introduced in v4.6.0)
- Enable python 3.13 tests, and add its classifier to pyproject.toml
- Adds concurrency rule in workflow to prevent more than on workflow run for the same commit or commit hash (inspired in packaging.python.org)