### PR TITLE
Cache using hash from pyproject.toml instead of setup.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
           fetch-depth: 1
 
       - name: pycache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pycache
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 


### PR DESCRIPTION
setup.py was removed in 42aa5a5d.

Also updates actions/cache version to solve the warning in GitHub Actions workflow run:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
