### PR TITLE
drop python<=3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
       max-parallel: 1
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Sphinx utility that make it easy to translate and to apply translation."
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 dependencies = [
     "setuptools",
@@ -26,9 +26,6 @@ classifiers = [
     "Topic :: Text Processing :: General",
     "Topic :: Utilities",
     "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -41,7 +38,6 @@ classifiers = [
 [project.optional-dependencies]
 test = [
     "pytest",
-    "mock",
 ]
 
 [project.urls]

--- a/sphinx_intl/__init__.py
+++ b/sphinx_intl/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 __version__ = '2.3.0'

--- a/sphinx_intl/__main__.py
+++ b/sphinx_intl/__main__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 if __name__ == '__main__':
     from sphinx_intl.commands import main
     main()

--- a/sphinx_intl/basic.py
+++ b/sphinx_intl/basic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 from glob import glob
 
@@ -53,23 +51,23 @@ def update(locale_dir, pot_dir, languages, line_width=76, ignore_obsolete=False)
                 cat_pot = c.load_po(pot_file)
                 if os.path.exists(po_file):
                     cat = c.load_po(po_file)
-                    msgids = set([m.id for m in cat if m.id])
+                    msgids = {m.id for m in cat if m.id}
                     c.update_with_fuzzy(cat, cat_pot)
-                    new_msgids = set([m.id for m in cat if m.id])
+                    new_msgids = {m.id for m in cat if m.id}
                     if msgids != new_msgids:
                         added = new_msgids - msgids
                         deleted = msgids - new_msgids
                         status['update'] += 1
-                        click.echo('Update: {0} +{1}, -{2}'.format(
+                        click.echo('Update: {} +{}, -{}'.format(
                             po_file, len(added), len(deleted)))
                         c.dump_po(po_file, cat, width=line_width,
                                   ignore_obsolete=ignore_obsolete)
                     else:
                         status['notchanged'] += 1
-                        click.echo('Not Changed: {0}'.format(po_file))
+                        click.echo(f'Not Changed: {po_file}')
                 else:  # new po file
                     status['create'] += 1
-                    click.echo('Create: {0}'.format(po_file))
+                    click.echo(f'Create: {po_file}')
                     cat_pot.locale = lang
                     c.dump_po(po_file, cat_pot, width=line_width,
                               ignore_obsolete=ignore_obsolete)
@@ -102,7 +100,7 @@ def build(locale_dir, output_dir, languages):
                 if (os.path.exists(mo_file) and
                    os.path.getmtime(mo_file) > os.path.getmtime(po_file)):
                     continue
-                click.echo('Build: {0}'.format(mo_file))
+                click.echo(f'Build: {mo_file}')
                 cat = c.load_po(po_file)
                 c.write_mo(mo_file, cat)
 
@@ -134,7 +132,7 @@ def stat(locale_dir, languages):
                     'untranslated': len(c.untranslated_entries(cat)),
                 }
                 click.echo(
-                    '{0}: {1} translated, {2} fuzzy, {3} untranslated.'.format(
+                    '{}: {} translated, {} fuzzy, {} untranslated.'.format(
                         po_file,
                         r['translated'],
                         r['fuzzy'],

--- a/sphinx_intl/catalog.py
+++ b/sphinx_intl/catalog.py
@@ -1,5 +1,4 @@
 import os
-import io
 
 from babel.messages import pofile, mofile
 

--- a/sphinx_intl/catalog.py
+++ b/sphinx_intl/catalog.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import io
 
@@ -14,13 +12,13 @@ def load_po(filename, **kwargs):
     :return: catalog object
     """
     # pre-read to get charset
-    with io.open(filename, 'rb') as f:
+    with open(filename, 'rb') as f:
         cat = pofile.read_po(f)
     charset = cat.charset or 'utf-8'
 
     # To decode lines by babel, read po file as binary mode and specify charset for
     # read_po function.
-    with io.open(filename, 'rb') as f:  # FIXME: encoding VS charset
+    with open(filename, 'rb') as f:  # FIXME: encoding VS charset
         return pofile.read_po(f, charset=charset, **kwargs)
 
 
@@ -46,7 +44,7 @@ def dump_po(filename, catalog, **kwargs):
         del kwargs['line_width']
 
     # Because babel automatically encode strings, file should be open as binary mode.
-    with io.open(filename, 'wb') as f:
+    with open(filename, 'wb') as f:
         pofile.write_po(f, catalog, **kwargs)
 
 
@@ -60,7 +58,7 @@ def write_mo(filename, catalog, **kwargs):
     dirname = os.path.dirname(filename)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
-    with io.open(filename, 'wb') as f:
+    with open(filename, 'wb') as f:
         mofile.write_mo(f, catalog, **kwargs)
 
 

--- a/sphinx_intl/commands.py
+++ b/sphinx_intl/commands.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     sphinx-intl
     ~~~~~~~~~~~
@@ -196,11 +195,11 @@ def main(ctx, config, tag):
     ctx.transifex_project_name = None
     target = os.path.normpath('.tx/config')
     if os.path.exists(target):
-        matched = re.search(r'\[(.*)\..*\]', open(target, 'r').read())
+        matched = re.search(r'\[(.*)\..*\]', open(target).read())
         if matched:
             ctx.transifex_project_name = matched.groups()[0]
             click.echo(
-                'Project name loaded from .tx/config: {0}'.format(
+                'Project name loaded from .tx/config: {}'.format(
                     ctx.transifex_project_name))
 
     ctx.default_map = {

--- a/sphinx_intl/sphinx_util.py
+++ b/sphinx_intl/sphinx_util.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 from typing import Iterator, List
 
 
 # port from https://github.com/sphinx-doc/sphinx/blob/ad41e0b/sphinx/util/tags.py
-class Tags(object):
+class Tags:
     def __init__(self, tags: List[str] = None) -> None:
         self.tags = dict.fromkeys(tags or [], True)
 

--- a/sphinx_intl/transifex.py
+++ b/sphinx_intl/transifex.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import re
 import subprocess
@@ -108,7 +106,7 @@ def create_transifexrc(transifex_token):
     target = os.path.normpath(os.path.expanduser('~/.transifexrc'))
 
     if os.path.exists(target):
-        click.echo('{0} already exists, skipped.'.format(target))
+        click.echo(f'{target} already exists, skipped.')
         return
 
     if not transifex_token:
@@ -118,9 +116,9 @@ def create_transifexrc(transifex_token):
         """)
         raise click.BadParameter(msg, param_hint='transifex_token')
 
-    with open(target, 'wt') as rc:
+    with open(target, 'w') as rc:
         rc.write(TRANSIFEXRC_TEMPLATE % locals())
-    click.echo('Create: {0}'.format(target))
+    click.echo(f'Create: {target}')
 
 
 def create_txconfig():
@@ -129,16 +127,16 @@ def create_txconfig():
     """
     target = os.path.normpath('.tx/config')
     if os.path.exists(target):
-        click.echo('{0} already exists, skipped.'.format(target))
+        click.echo(f'{target} already exists, skipped.')
         return
 
     if not os.path.exists('.tx'):
         os.mkdir('.tx')
 
-    with open(target, 'wt') as f:
+    with open(target, 'w') as f:
         f.write(TXCONFIG_TEMPLATE)
 
-    click.echo('Create: {0}'.format(target))
+    click.echo(f'Create: {target}')
 
 
 def update_txconfig_resources(transifex_organization_name, transifex_project_name,
@@ -182,4 +180,4 @@ def update_txconfig_resources(transifex_organization_name, transifex_project_nam
                 cmd = [arg % lv for arg in cmd_tmpl]
                 subprocess.check_output(cmd, shell=False)
             else:
-                click.echo('{0} is empty, skipped'.format(pot_path))
+                click.echo(f'{pot_path} is empty, skipped')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     conftest
     ~~~~~~~~

--- a/tests/path.py
+++ b/tests/path.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
     path
     ~~~~
@@ -183,4 +182,4 @@ class path(str):
     __div__ = __truediv__ = joinpath
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, str.__repr__(self))
+        return '{}({})'.format(self.__class__.__name__, str.__repr__(self))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     test_basic
     ~~~~~~~~~~
@@ -8,7 +7,7 @@
     :copyright: Copyright 2019 by Takayuki SHIMIZUKAWA.
     :license: BSD, see LICENSE for details.
 """
-import mock
+from unittest import mock
 
 from sphinx_intl import basic
 
@@ -26,7 +25,7 @@ def test_update_difference_detect(temp):
     r2 = basic.update('locale', '_build/locale', ('ja',))
     assert r2 == {'create': 0, 'update': 1, 'notchanged': 0}
 
-    with open('_build/locale/README.pot', 'r') as f:
+    with open('_build/locale/README.pot') as f:
         d = f.read()
         d = d.replace('test1', 'test2')
     with open('_build/locale/README.pot', 'w') as f:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     test_catalog
     ~~~~~~~~~~~~
@@ -15,7 +14,7 @@ def test_write_and_read_po_file_with_non_ascii_string(temp):
     from sphinx_intl import catalog
 
     cat = Catalog(locale='ja', domain='domain', fuzzy=False)
-    msg = Message('Hello World', u'こんにちは世界')
+    msg = Message('Hello World', 'こんにちは世界')
     cat[msg.id] = msg
 
     po_file = (temp / 'domain.po')
@@ -30,7 +29,7 @@ def test_fuzzy_flag_on_catalog_update():
 
     cat = Catalog(locale='ja', domain='domain', fuzzy=False)
     msg = Message('Hello Internationalized Sphinx World !',
-                  u'こんにちは国際化されたSphinxの世界!')
+                  'こんにちは国際化されたSphinxの世界!')
     cat[msg.id] = msg
     assert not msg.fuzzy
 

--- a/tests/test_cmd_pot.py
+++ b/tests/test_cmd_pot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     test_cmd_pot
     ~~~~~~~~~~~~~
@@ -51,7 +50,7 @@ def test_update_difference_detect(temp):
     assert r2.output.count('Update:') == 1
     assert r2.output.count('Not Changed:') == 0
 
-    with open('_build/locale/README.pot', 'r') as f:
+    with open('_build/locale/README.pot') as f:
         d = f.read()
         d = d.replace('test1', 'test2')
     with open('_build/locale/README.pot', 'w') as f:
@@ -71,7 +70,7 @@ def test_update_difference_detect(temp):
 
 
 def test_update_line_width(temp):
-    with open('_build/locale/README.pot', 'r') as f:
+    with open('_build/locale/README.pot') as f:
         template = f.read()
 
     with open('_build/locale/README.pot', 'w') as f:
@@ -84,7 +83,7 @@ def test_update_line_width(temp):
     r1 = runner.invoke(commands.update, ['-d', 'locale', '-p', '_build/locale', '-l', 'ja'])
     assert r1.exit_code == 0
 
-    with open(po_file, 'r') as f:
+    with open(po_file) as f:
         contents = f.read()
         assert '"foorbar identifier1"\n' in contents
 
@@ -96,14 +95,14 @@ def test_update_line_width(temp):
     r2 = runner.invoke(commands.update, ['-d', 'locale', '-p', '_build/locale', '-w', '1'])
     assert r2.exit_code == 0
 
-    with open(po_file, 'r') as f:
+    with open(po_file) as f:
         contents = f.read()
         assert '"foorbar"\n' in contents
         assert '"identifier2"\n' in contents
 
 
 def test_update_no_obsolete(temp):
-    with open('_build/locale/README.pot', 'r') as f:
+    with open('_build/locale/README.pot') as f:
         template = f.read()
 
     with open('_build/locale/README.pot', 'w') as f:
@@ -117,7 +116,7 @@ def test_update_no_obsolete(temp):
     r1 = runner.invoke(commands.update, ['-d', 'locale', '-p', '_build/locale', '-l', 'ja'])
     assert r1.exit_code == 0
 
-    with open(po_file, 'r') as f:
+    with open(po_file) as f:
         contents = f.read()
         assert '\nmsgid "foorbar1"\n' in contents
         assert '\nmsgid "foorbar2"\n' in contents
@@ -130,7 +129,7 @@ def test_update_no_obsolete(temp):
     r2 = runner.invoke(commands.update, ['-d', 'locale', '-p', '_build/locale'])
     assert r2.exit_code == 0
 
-    with open(po_file, 'r') as f:
+    with open(po_file) as f:
         contents = f.read()
         assert '\n#~ msgid "foorbar2"\n' in contents
 
@@ -141,7 +140,7 @@ def test_update_no_obsolete(temp):
     r3 = runner.invoke(commands.update, ['-d', 'locale', '-p', '_build/locale', '--no-obsolete'])
     assert r3.exit_code == 0
 
-    with open(po_file, 'r') as f:
+    with open(po_file) as f:
         contents = f.read()
         assert 'msgid "foorbar1"' not in contents
         assert 'msgid "foorbar2"' not in contents

--- a/tests/test_cmd_transifex.py
+++ b/tests/test_cmd_transifex.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     test_cmd_transifex
     ~~~~~~~~~~~~~~~~~~

--- a/tests/test_transifex.py
+++ b/tests/test_transifex.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     test_transifex
     ~~~~~~~~~~~~~~


### PR DESCRIPTION
iAccording to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all python cde over `pyupgrade --py38-plus`.