### PR TITLE
Modernize release procedures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ Documentation = "https://sphinx-intl.readthedocs.io"
 sphinx-intl = "sphinx_intl.commands:main"
 
 [tool.setuptools]
-zip-safe = false
 include-package-data = true
 
 [tool.setuptools.dynamic]
@@ -57,3 +56,7 @@ version = {attr = "sphinx_intl.__version__"}
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+ignore_missing_imports = true
+strict_optional = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,23 +1,17 @@
-# to bulid release:
-# 1. COMMENT OUT `[egg_info]` section
-# 2. $ pip install build
-# 3. $ python -m build
+# 1. initialize
+# $ pip install -U build twine
 
-# to test upload:
+# 2. TEST build & release:
+# $ rm -Rf build/
+# $ python -m build
 # $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
-# to production upload:
+# 3. PRODUCTION build & release:
+# $ rm -Rf build/
+# $ rm setup.cfg
+# $ python -m build
 # $ twine upload dist/*
 
 [egg_info]
 tag_build = dev
 tag_date = true
-
-[flake8]
-;show-pep8=true
-;show-source=true
-max-line-length=95
-
-[mypy]
-ignore_missing_imports = True
-strict_optional = False

--- a/tox.ini
+++ b/tox.ini
@@ -38,3 +38,8 @@ deps=
     docutils
     wheel
 commands={envpython} setup.py -q check -r -s sdist bdist_wheel
+
+[flake8]
+# show-pep8=true
+# show-source=true
+max-line-length=95


### PR DESCRIPTION
- move **mypy** settings from `setup.cfg` to `pyproject.toml`
- move **flake8** settings from `setup.cfg` to `tox.ini` because flake8 doesn't support pyproject.toml.
- update build procedure in `setup.cfg` 
- remove dprecated option for setuptools from `pyproject.toml`

