### PR TITLE
Avoid unrelated CI test for doc changes, and cache using setup-python action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,20 +31,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: pycache
-        uses: actions/cache@v4
-        id: pycache
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+          cache: 'pip'
 
       - name: Install tox and test related
         run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ CHANGES
 Environments
 ------------
 
+* Avoid unrelated CI test for doc changes, and cache using setup-python action  by @rffontenelle in https://github.com/sphinx-doc/sphinx-intl/pull/106
+
 Incompatibility
 ---------------
 


### PR DESCRIPTION
Since test.yml doesn't run any CI related-test, [excluding doc path](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths) seems the ideal thing to not unnecessarily run test across several Python versions.

Also, caching pip dependencies with actions/setup-python [will search pyproject.toml by default](https://github.com/actions/setup-python/tree/main?tab=readme-ov-file#caching-packages-dependencies), so it is not necessary to keep actions/cache for this case.