### PR TITLE
Perform update in parallel

### DIFF
--- a/sphinx_intl/commands.py
+++ b/sphinx_intl/commands.py
@@ -157,6 +157,18 @@ option_line_width = click.option(
     "disable line wrapping",
 )
 
+option_jobs = click.option(
+    "-j",
+    "--jobs",
+    envvar=ENVVAR_PREFIX + "_JOBS",
+    type=int,
+    default=0,
+    metavar="<JOBS>",
+    show_default=True,
+    multiple=False,
+    help="The number of CPUs to use for updates. 0 means all",
+)
+
 option_no_obsolete = click.option(
     "--no-obsolete",
     envvar=ENVVAR_PREFIX + "_NO_OBSOLETE",
@@ -271,7 +283,8 @@ def main(ctx, config, tag):
 @option_language
 @option_line_width
 @option_no_obsolete
-def update(locale_dir, pot_dir, language, line_width, no_obsolete):
+@option_jobs
+def update(locale_dir, pot_dir, language, line_width, no_obsolete, jobs):
     """
     Update specified language's po files from pot.
 
@@ -300,7 +313,12 @@ def update(locale_dir, pot_dir, language, line_width, no_obsolete):
         raise click.BadParameter(msg, param_hint="language")
 
     basic.update(
-        locale_dir, pot_dir, languages, line_width, ignore_obsolete=no_obsolete
+        locale_dir,
+        pot_dir,
+        languages,
+        line_width,
+        ignore_obsolete=no_obsolete,
+        jobs=jobs,
     )
 
 


### PR DESCRIPTION
The update command implementation runs over files that are independent from each other. As such, the overall update operation can be trivially parallelised to speed things up.

This change introduces  The list of files that need to be compared/updated is collected in a first past. This list is then given to a multiprocessing pool to farm out the actual update of each individual file. The amount of parallelism is controlled through a new "jobs" parameter, command line option and environment variable. If no value is given for this option, all CPUs are used.

I noticed this chance for improvement when doing a test run of the update of .po files for the Spanish translation of the CPython documentation. Local numbers in my 8-core, hyper-threaded AMD Ryzen 7 5825U:

```
-j 1 (same as old behaviour)

real    12m5.402s
user    12m4.942s
sys     0m0.273s

-j 8

real    2m23.609s
user    17m45.201s
sys     0m0.460s

<no value given>

real    1m57.398s
user    26m22.654s
sys     0m0.989s
```