### PR TITLE
Redesign load_po to use Lex/Yacc state transitions style, to ease mai…

### DIFF
--- a/sphinx_intl/catalog.py
+++ b/sphinx_intl/catalog.py
@@ -1,6 +1,6 @@
 import os
 
-from babel.messages import pofile, mofile
+from babel.messages import pofile, mofile, poparse
 
 
 def load_po(filename, **kwargs):
@@ -10,15 +10,16 @@ def load_po(filename, **kwargs):
     :param kwargs: keyword arguments to forward to babel's read_po call
     :return: catalog object
     """
-    # pre-read to get charset
-    with open(filename, "rb") as f:
-        cat = pofile.read_po(f)
-    charset = cat.charset or "utf-8"
-
-    # To decode lines by babel, read po file as binary mode and specify charset for
-    # read_po function.
-    with open(filename, "rb") as f:  # FIXME: encoding VS charset
-        return pofile.read_po(f, charset=charset, **kwargs)
+    return poparse.load_po(filename, **kwargs)
+    # # pre-read to get charset
+    # with open(filename, "rb") as f:
+    #     cat = pofile.read_po(f)
+    # charset = cat.charset or "utf-8"
+    #
+    # # To decode lines by babel, read po file as binary mode and specify charset for
+    # # read_po function.
+    # with open(filename, "rb") as f:  # FIXME: encoding VS charset
+    #     return pofile.read_po(f, charset=charset, **kwargs)
 
 
 def dump_po(filename, catalog, **kwargs):


### PR DESCRIPTION
maintenance and also speed up the parsing using multiprocessing option, including debugging, abort if invalid in multiprocessing as well as in linear processing mode, plus custom hook to system's exception handling to not show the frame stacks tracing. User now can just use

load_po(filename, debug=True, multiprocessing=True, hookexcept=True, batch_size_division=3 ...)

Please read the documentation of poparse.load_po() for further details.