### PR TITLE
FIX: set `exist_ok=True` in `os.makedirs()`

### DIFF
--- a/sphinx_intl/catalog.py
+++ b/sphinx_intl/catalog.py
@@ -32,8 +32,7 @@ def dump_po(filename, catalog, **kwargs):
     :return: None
     """
     dirname = os.path.dirname(filename)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname)
+    os.makedirs(dirname, exist_ok=True)
 
     # (compatibility) line_width was the original argument used to forward
     # line width hints into write_po's `width` argument; if provided,
@@ -55,8 +54,8 @@ def write_mo(filename, catalog, **kwargs):
     :return: None
     """
     dirname = os.path.dirname(filename)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname)
+    os.makedirs(dirname, exist_ok=True)
+
     with open(filename, "wb") as f:
         mofile.write_mo(f, catalog, **kwargs)
 


### PR DESCRIPTION
replaces a non-atomic pattern for directory creation:

    if not os.path.exists(dirname):
        os.makedirs(dirname)

with the safer:

    os.makedirs(dirname, exist_ok=True)

In the parallel state (merged in #110 ), the original pattern is prone to race conditions: two processes may check for directory existence and both attempt to create it at the same time, will case **FileExistsError**. Using `exist_ok=True` makes directory creation atomic and thread-safe.