### PR TITLE
fixes #116: Update doesn't respect default value of locale_dirs from `-c` passed `conf.py`

### DIFF
--- a/sphinx_intl/commands.py
+++ b/sphinx_intl/commands.py
@@ -233,10 +233,11 @@ def main(ctx, config, tag):
     ctx.locale_dir = None
     if ctx.config:
         cfg = read_config(ctx.config, tag)
-        if "locale_dirs" in cfg:
-            ctx.locale_dir = os.path.join(
-                os.path.dirname(ctx.config), cfg["locale_dirs"][0]
-            )
+        # Use explicit locale_dirs if set, otherwise use Sphinx's default ['locales']
+        locale_dirs = cfg.get("locale_dirs", ["locales"])
+        ctx.locale_dir = os.path.join(
+            os.path.dirname(ctx.config), locale_dirs[0]
+        )
 
     # for pot_dir
     ctx.pot_dir = None

--- a/tests/test_locale_dirs_default.py
+++ b/tests/test_locale_dirs_default.py
@@ -1,0 +1,65 @@
+"""
+    test_locale_dirs_default
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Test locale_dirs default value handling.
+
+    :copyright: Copyright 2025 by Takayuki SHIMIZUKAWA.
+    :license: BSD, see LICENSE for details.
+"""
+import os
+from unittest import mock
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from sphinx_intl.commands import main
+
+
+def test_locale_dirs_explicit_setting(tmp_path: Path):
+    """Test that explicit locale_dirs setting is respected in ctx.locale_dir."""
+    # Arrange
+    conf_content = """locale_dirs = ['custom_locale']"""
+    conf_path = tmp_path / 'conf.py'
+    conf_path.write_text(conf_content)
+    pot_dir = tmp_path / '_build' / 'gettext'
+    pot_dir.mkdir(parents=True)
+    (pot_dir / 'test.pot').write_text('msgid "test"')
+    
+    # Act
+    with mock.patch('sphinx_intl.commands.basic.update') as mock_update:
+        result = CliRunner().invoke(main, ['-c', str(conf_path), 'update', '-p', str(pot_dir), '-l', 'ja'])
+        
+    # Assert
+    assert mock_update.called, "basic.update should have been called"
+    called_locale_dir = mock_update.call_args[0][0]
+    expected_locale_dir = str(tmp_path / 'custom_locale')
+    assert called_locale_dir == expected_locale_dir
+
+
+def test_locale_dirs_default_value(tmp_path: Path):
+    """
+    Test that default locale_dirs value ['locales'] is used when not specified.
+    
+    This also serves as a regression test for issue #116: locale_dir should be
+    set relative to conf.py location, not relative to the current working directory.
+    """
+    # Arrange
+    # No locale_dirs setting - should use default ['locales']
+    conf_content = """project = 'test'"""
+    conf_path = tmp_path / 'conf.py'
+    conf_path.write_text(conf_content)
+    pot_dir = tmp_path / '_build' / 'gettext'
+    pot_dir.mkdir(parents=True)
+    (pot_dir / 'test.pot').write_text('msgid "test"')
+    
+    # Act
+    with mock.patch('sphinx_intl.commands.basic.update') as mock_update:
+        result = CliRunner().invoke(main, ['-c', str(conf_path), 'update', '-p', str(pot_dir), '-l', 'ja'])
+        
+    # Assert
+    assert mock_update.called, "basic.update should have been called"
+    called_locale_dir = mock_update.call_args[0][0]
+    expected_locale_dir = str(tmp_path / 'locales')
+    assert called_locale_dir == expected_locale_dir


### PR DESCRIPTION
fixes #116