### PR TITLE
#123: Release to PyPI with digital attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Test, Build, Publish, Release
+name: Test
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,30 @@ jobs:
           name: distributions
           path: dist/
 
-  pypi-publish:
+  publish-to-testpypi:
+    name: Upload release to TestPyPI
+    if: github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master'  # only publish to TestPyPI on push to master
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/sphinx-intl
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: distributions
+          path: dist/
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
     name: Upload release to PyPI
     if: github.repository_owner == 'sphinx-doc' && startsWith(github.ref, 'refs/tags/')
     needs:
@@ -102,36 +125,45 @@ jobs:
         with:
           verbose: true
 
-          # for test
-          password: ${{ secrets.TESTPYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-
-          # for production
-          # password: ${{ secrets.PYPI_TOKEN }}
-
   github-release:
-    name: GitHub release
+    name: Sign the Python 🐍 distribution 📦 with Sigstore and upload them to GitHub Release
     if: github.repository_owner == 'sphinx-doc'
+    needs:
+    - publish-to-pypi
     runs-on: ubuntu-latest
     needs:
       - pypi-publish
     environment: release
     permissions:
-      contents: write  # for softprops/action-gh-release to create GitHub release
-
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
     steps:
-      - uses: actions/checkout@v4
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
         with:
-          persist-credentials: false
-      - name: Get release version
-        id: get_version
-        uses: actions/github-script@v7
+          name: distributions
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
-          script: core.setOutput('version', context.ref.replace("refs/tags/", ""))
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          name: "sphinx-intl ${{ steps.get_version.outputs.version }}"
-          body: "Changelog: https://sphinx-intl.readthedocs.io/en/master/changes.html"
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          "$GITHUB_REF_NAME"
+          --repo "$GITHUB_REPOSITORY"
+          --notes ""
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          "$GITHUB_REF_NAME" dist/**
+          --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test, Build, Publish, Release
 on:
   push:
     paths-ignore:
@@ -55,7 +55,7 @@ jobs:
 
   build:
     name: build distribution
-    if: github.repository_owner == 'sphinx-doc'
+    if: github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master'
     needs:
       - tests
     runs-on: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
 
   publish-to-testpypi:
     name: Upload release to TestPyPI
-    if: github.repository_owner == 'sphinx-doc'
+    if: github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master'  # only publish to TestPyPI on push to master
     needs:
       - build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
   publish-to-testpypi:
     name: Upload release to TestPyPI
-    if: github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master'  # only publish to TestPyPI on push to master
+    if: github.repository_owner == 'sphinx-doc'
     needs:
       - build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Test, Build, Publish, Release
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6
@@ -64,7 +64,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Python
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
   build:
     name: build distribution
-    if: github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master'
+    if: ${{ github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master' }}
     needs:
       - tests
     runs-on: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
 
   publish-to-testpypi:
     name: Upload release to TestPyPI
-    if: github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master'  # only publish to TestPyPI on push to master
+    if: ${{ github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master' }}  # only publish to TestPyPI on push to master
     needs:
       - build
     runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
 
   publish-to-pypi:
     name: Upload release to PyPI
-    if: github.repository_owner == 'sphinx-doc' && startsWith(github.ref, 'refs/tags/')
+    if: ${{ github.repository_owner == 'sphinx-doc' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - build
     runs-on: ubuntu-latest
@@ -128,10 +128,10 @@ jobs:
 
   github-release:
     name: Sign the Python 🐍 distribution 📦 with Sigstore and upload them to GitHub Release
-    if: github.repository_owner == 'sphinx-doc'
+    if: ${{ github.repository_owner == 'sphinx-doc' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
     needs:
       - publish-to-pypi
-    runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
@@ -148,14 +148,6 @@ jobs:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create
-          "$GITHUB_REF_NAME"
-          --repo "$GITHUB_REPOSITORY"
-          --notes ""
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
   build:
     name: build distribution
-    if: github.repository_owner == 'sphinx-doc' && github.ref == 'refs/heads/master'
+    if: github.repository_owner == 'sphinx-doc'
     needs:
       - tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,8 @@ jobs:
     name: Sign the Python 🐍 distribution 📦 with Sigstore and upload them to GitHub Release
     if: github.repository_owner == 'sphinx-doc'
     needs:
-    - publish-to-pypi
+      - publish-to-pypi
     runs-on: ubuntu-latest
-    needs:
-      - pypi-publish
     environment: release
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Environments
 ------------
 
 * add python-3.14 support by @rffontenelle in https://github.com/sphinx-doc/sphinx-intl/pull/115
+* Release to PyPI with digital attestations (PEP-740) by @shimizukawa in https://github.com/sphinx-doc/sphinx-intl/pull/125
 
 Incompatibility
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,9 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools_scm]
-# this empty section means: use_scm_version=True
+# https://setuptools-scm.readthedocs.io/en/latest/extending/#available-implementations_1
+# because pypi does not support local version like .devN+<local_version>
+local_scheme = "no-local-version"
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
PEP 740 - Index support for digital attestations
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/